### PR TITLE
ゲームの終了コマンドを入力したあと敵との戦闘が始まる場合があったのを修正

### DIFF
--- a/io-linux.lisp
+++ b/io-linux.lisp
@@ -81,7 +81,9 @@
       (q (select-heal pt 0 0 0))
        (i
         (show-item pt))
-      (r (setf *end* 2))
+      (r
+       (setf *end* 2)
+       (return-from map-move))
       (otherwise
        (scr-format "w,a,s,d,q,rの中から選んでください！~%")))
     (encount-enemy pt map) ;;敵との当たり判定


### PR DESCRIPTION
rを押したあとに敵との当たり判定があるので、ゲームが終了する前に戦闘が始まる場合がありました。